### PR TITLE
add code to set a custom user agent "wfs-downloader/0.5"

### DIFF
--- a/wfs_downloader/download.py
+++ b/wfs_downloader/download.py
@@ -3,13 +3,16 @@ from __future__ import print_function
 import argparse
 import os
 import yaml
+import sys
 
 try:
     # py2
     from urllib import urlretrieve
+    import urllib
 except ImportError:
     # py3
     from urllib.request import urlretrieve
+    import urllib.request
 
 from lxml import etree
 
@@ -33,6 +36,16 @@ def main():
 
 
 def download_files(config):
+
+    if (sys.version_info > (3, 0)):
+        # Python 3 code in this block
+        opener = urllib.request.build_opener()
+        opener.addheaders = [('User-agent', 'wfs-downloader/0.1')]
+        urllib.request.install_opener(opener)
+    else:
+        # Python 2 code in this block
+        urllib.URLopener.version = "wfs-downloader/0.1"
+
     west_range = list(arange(config['bbox']['west'], config['bbox']['east'], config['size']))
     south_range = list(arange(config['bbox']['south'], config['bbox']['north'], config['size']))
 


### PR DESCRIPTION
Berlin's FIS Broker WFS service apparently rejects the standard Python urllib user agent. This code changes the user agent to "wfs-downloader/0.5", which seemingly makes FIS Broker happy again.

I have added code for both Python 2 and Python 3 and "tested" both by running the script with the example config.